### PR TITLE
Add command to send top level form to repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Keyboard shortcuts below refer to using `ctrl-,` then a letter. That means press
 | `ctrl-, k`       | `proto-repl:clear-repl`               | Clears REPL Output                                                                                                                       |
 | `ctrl-shift-, s` | `proto-repl:toggle-auto-scroll`       | Enables/Disables autoscrolling the REPL                                                                                                  |
 | `ctrl-, b`       | `proto-repl:execute-block`            | Sends the current block of Clojure code to the REPL for execution.                                                                       |
+|                  | `proto-repl:execute-top-block`        | Sends the current top-level block of Clojure code to the REPL for execution.                                                                       |
 | `ctrl-, s`       | `proto-repl:execute-selected-text`    | Sends the selected text to the REPL for execution.                                                                                       |
 | `ctrl-, f`       | `proto-repl:load-current-file`        | Loads the current file in the repl.                                                                                                      |
 | `ctrl-, r`       | `proto-repl:refresh-namespaces`       | Runs the `user/reset` function. See [My Clojure Workflow, Reloaded](http://thinkrelevance.com/blog/2013/06/04/clojure-workflow-reloaded) |

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -37,6 +37,7 @@ module.exports = ProtoRepl =
       'proto-repl:toggle-auto-scroll': => @toggleAutoScroll()
       'proto-repl:execute-selected-text': => @executeSelectedText()
       'proto-repl:execute-block': => @executeBlock()
+      'proto-repl:execute-top-block': => @executeBlock({topLevel: true})
       'proto-repl:load-current-file': => @loadCurrentFile()
       'proto-repl:refresh-namespaces': => @refreshNamespaces()
       'proto-repl:super-refresh-namespaces': => @superRefreshNamespaces()
@@ -142,9 +143,9 @@ module.exports = ProtoRepl =
     if editor = atom.workspace.getActiveTextEditor()
       @executeCodeInNs(editor.getSelectedText())
 
-  executeBlock: ->
+  executeBlock: (options)->
     if editor = atom.workspace.getActiveTextEditor()
-      if range = EditorUtils.getCursorInBlockRange(editor)
+      if range = EditorUtils.getCursorInBlockRange(editor, options)
         text = editor.getTextInBufferRange(range).trim()
 
         # Highlight the area that's being executed temporarily


### PR DESCRIPTION
Having used Cursive, I've got used to sending an entire top level form to the repl, not just the nearest one. 

This PR adds the `proto-repl:execute-top-block` command. I've updated the readme, but I haven't added a new keybinding.
