### PR TITLE
Check if process is running before attempting to close connection

### DIFF
--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -64,7 +64,8 @@ class Repl
     # The window was closed
     @replTextEditor.onDidClose =>
       try
-        @process?.stop(@session)
+        if @running()
+          @process?.stop(@session)
         @replTextEditor = null
         @emitter.emit 'proto-repl-repl:close'
       catch error


### PR DESCRIPTION
I don't know if this covers all cases of issue #62, but one scenario I've found is if the REPL fails to ever start a session (e.g. starting from outside a Lein project, and/or Lein cannot be found) then the breakdown process will fail when trying to close a `null` session. This leaves a dangling `@repl` reference with no session behind it. Seems like this can be resolved by simply checking if the process is running before attempting to stop it. I'm not extremely familiar with this code base though, is there a better solution available?
