### PR TITLE
Run the 'dev' boot task before starting 'repl'

### DIFF
--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -40,7 +40,7 @@ module.exports = ProtoRepl =
     bootArgs:
       description: 'The arguments to be passed to boot. For advanced users only.'
       type: 'string'
-      default: "--no-colors repl"
+      default: "--no-colors dev repl"
     preferLein:
       description: "Sets whether to prefer Leiningen if a boot and lein build file is found."
       type: 'boolean'


### PR DESCRIPTION
There is an expectation for a deftask named 'dev' in the build.boot file. 
This change causes that 'dev' task to be run before the 'repl' task.
In Leiningen land the 'dev' profile is used by default and does not need an argument.
There should be something about the 'dev' profile/task in the documentation.
