### PR TITLE
windows version of boot is an exe not a bat

### DIFF
--- a/lib/process/boot-runner.coffee
+++ b/lib/process/boot-runner.coffee
@@ -11,10 +11,10 @@ module.exports = (currentWorkingDir, bootPath, args) ->
   try
     if process.platform == "win32"
       # Windows
-      if bootPath.endsWith("boot.bat")
+      if bootPath.endsWith("boot.exe")
         bootExec = bootPath
       else
-        bootExec = path.join(bootPath, "boot.bat")
+        bootExec = path.join(bootPath, "boot.exe")
       envPath = filteredEnv["Path"] || ""
       filteredEnv["Path"] = envPath + path.delimiter + bootPath
     else

--- a/lib/process/boot-runner.coffee
+++ b/lib/process/boot-runner.coffee
@@ -25,14 +25,11 @@ module.exports = (currentWorkingDir, bootPath, args) ->
 
     replProcess = childProcess.spawn bootExec, args, cwd: currentWorkingDir, env: filteredEnv
 
-    replProcess.on 'error', (error)->
-      processData("Error starting repl: " + error +
-      "\nYou may need to configure the boot path in proto-repl settings\n")
 
     # The nREPL port is extracted from the output of the REPL process. We could
     # look on the file system for the .nrepl-port file which is more standard
     # but there are issues if you want to start multiple REPLs in the same project.
-    # proto-repl-process:nrepl-port is emitted with the nREPL port is found.
+    # proto-repl-process:nrepl-port is emitted when the nREPL port is found.
     portFound = false
 
     processData = (data) ->
@@ -45,6 +42,14 @@ module.exports = (currentWorkingDir, bootPath, args) ->
           emit('proto-repl-process:nrepl-port', port)
 
       emit('proto-repl-process:data', dataStr)
+
+    processData("repl started")
+    processData("exec: " + bootExec)
+    processData("args: " + args)
+
+    replProcess.on 'error', (error)->
+        processData("Error starting repl: " + error +
+        "\nYou may need to configure the boot path in proto-repl settings\n")
 
     replProcess.stdout.on 'data', processData
     replProcess.stderr.on 'data', processData

--- a/lib/process/local-repl-process.coffee
+++ b/lib/process/local-repl-process.coffee
@@ -115,7 +115,6 @@ class LocalReplProcess
 
     # The process exited.
     @process.on 'proto-repl-process:exit', ()=>
-      @appendText("\nREPL Closed\n")
       # The REPL Text editor may or may not be still open at this point.
       # We track that separately.
       @process = null
@@ -132,7 +131,6 @@ class LocalReplProcess
 
   interrupt: ->
     @conn.interrupt()
-    @appendText("Interrupting")
 
   # Stops the running process
   stop: ()->

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -43,7 +43,7 @@ module.exports = ProtoRepl =
     bootArgs:
       description: 'The arguments to be passed to boot. For advanced users only.'
       type: 'string'
-      default: "--no-colors dev repl"
+      default: "--no-colors dev repl --server wait"
     preferLein:
       description: "Sets whether to prefer Leiningen if a boot and lein build file is found."
       type: 'boolean'


### PR DESCRIPTION
Pretty much what the subject says. Unlike Leiningen, the Boot process is started by 'boot.exe' not 'boot.bat'.
https://github.com/boot-clj/boot#windows

There is a second change here as well.
This one changes the defaults to be:

--no-color dev repl --server wait

The --server wait is new.
'repl --server' causes the server to start 'headless' like the Leiningen default args.
By default starting the repl is not the final task and the only reason the repl stays open is because a client is attached to it. 
The 'wait' task holds the 'reple --server' open.
