### PR TITLE
red font for inline-errors as provided by ink

### DIFF
--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -164,7 +164,7 @@ class Repl
   # Displays some result data inline. tree is a recursive structure expected to
   # be of the shape like the following.
   # ["text for display", {button options}, [childtree1, childtree2, ...]]
-  displayInline: (editor, range, tree)->
+  displayInline: (editor, range, tree, error=false)->
     end = range.end.row
 
     # Remove the existing view if there is one
@@ -186,8 +186,7 @@ class Repl
     view = recurseTree(tree)
 
     # Add new inline view
-    r = new @ink.Result editor, [end, end],
-      content: view
+    r = new @ink.Result editor, [end, end], content: view, error: error
 
     # Adding the class here lets us apply proto repl specific styles to the display.
     r.view.classList.add 'proto-repl'
@@ -200,11 +199,13 @@ class Repl
   # of content for inline display.
   makeInlineHandler: (editor, range, valueToTreeFn)->
     (result) =>
+      isError = false
       if result.value
         tree = valueToTreeFn(result.value)
       else
         tree = [result.error]
-      @displayInline(editor, range, tree)
+        isError = true
+      @displayInline(editor, range, tree, isError)
 
   inlineResultHandler: (result, options)->
     # Alpha support of inline results using Atom Ink.


### PR DESCRIPTION
just to distinguish errors from correct results as provided by atom-ink's Result class (https://github.com/JunoLab/atom-ink/blob/master/docs/results.md)
![captura de pantalla de 2016-07-23 21 20 09](https://cloud.githubusercontent.com/assets/10408729/17079813/71639b9a-511b-11e6-80c2-7122c684ecfc.png)
