### PR TITLE
display error messages as a block in the next line

### DIFF
--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -186,7 +186,8 @@ class Repl
     view = recurseTree(tree)
 
     # Add new inline view
-    r = new @ink.Result editor, [end, end], content: view, error: error
+    r = new @ink.Result editor, [end, end],
+          content: view, error: error, type: if error then 'block' else 'inline'
 
     # Adding the class here lets us apply proto repl specific styles to the display.
     r.view.classList.add 'proto-repl'


### PR DESCRIPTION
This effectively changes the way Proto-repl displays inline results which are exceptions. The normal inline result just displays everything to the right but Clojure's exceptions are usually quite long so it is better to display them in the next line to use all the available space (see image).

The problem is that atom-ink had an issue with the CSS so the red text that was applied to inline-results (in my previous PR) was not applied to block-results, thus losing the error style. A patch was already applied to atom-ink so with the next release this shouldn't be a problem.

![captura de pantalla de 2016-07-28 12 47 54](https://cloud.githubusercontent.com/assets/10408729/17210409/12dafac2-54c3-11e6-8c5d-c272294d9a07.png)
