### PR TITLE
Update namespace only when responding to user REPL input

### DIFF
--- a/lib/process/nrepl-connection.coffee
+++ b/lib/process/nrepl-connection.coffee
@@ -81,8 +81,9 @@ class NReplConnection
       unless @namespaceNotFound(messages)
         for msg in messages
 
-          # Set the current ns
-          if msg.ns
+          # Set the current ns, but only if the message is in response
+          # to something sent by the user through the REPL
+          if msg.ns && msg.session == @session
             @currentNs = msg.ns
 
           if msg.session == @session


### PR DESCRIPTION
Provides a workaround for #133 

Not sure what the intent here but the issue stems from [this line](https://github.com/jasongilman/proto-repl/blob/34ff0987e19426dcea340f325377479e3bf4449c/lib/features/extensions-feature.coffee#L78) in the extensions feature.

The initial message with be sent with the default ("user" generally) namespace, the user will change the namespace (with, e.g. `ns`), but then the timeout for the initial message triggers a response that still has the "user" namespace, resetting it to the original value.

The workaround, and potentially the fix, is to only update the `@currentNs` variable when the message is for the user's REPL session.
