### PR TITLE
Add line numbers to repl

### DIFF
--- a/lib/process/nrepl-connection.coffee
+++ b/lib/process/nrepl-connection.coffee
@@ -152,10 +152,10 @@ class NReplConnection
       evalOptions = {op: "eval", code: wrappedCode, ns: ns, session: session}
       if options?.inlineOptions?.range?
         evalOptions.line = options.inlineOptions.range.start.row + 1
-        evalOptions.column = options.inlineOptions.range.start.col + 1
+        evalOptions.column = options.inlineOptions.range.start.column + 1
 
-      if options?.editor
-        evalOptions.file = options.editor.getPath()
+      if options?.inlineOptions?.editor
+        evalOptions.file = options.inlineOptions.editor.getPath()
 
       @conn.send evalOptions, (err, messages)=>
         try

--- a/lib/process/nrepl-connection.coffee
+++ b/lib/process/nrepl-connection.coffee
@@ -149,7 +149,15 @@ class NReplConnection
       wrappedCode = @wrapCodeInReadEval(code)
       ns = options.ns || @currentNs
 
-      @conn.eval wrappedCode, ns, session, (err, messages)=>
+      evalOptions = {op: "eval", code: wrappedCode, ns: ns, session: session}
+      if options?.inlineOptions?.range?
+        evalOptions.line = options.inlineOptions.range.start.row + 1
+        evalOptions.column = options.inlineOptions.range.start.col + 1
+
+      if options?.editor
+        evalOptions.file = options.editor.getPath()
+
+      @conn.send evalOptions, (err, messages)=>
         try
           # If the namespace hasn't been defined this will fail. We redefine the Namespace
           # and retry.


### PR DESCRIPTION
The default "eval" from nrepl connection doesn't gives us any information about line numbers, so it's kinda hard to debug code that we send to REPL:

![image](https://cloud.githubusercontent.com/assets/138037/17593622/ea397fda-5fbc-11e6-810b-395451303068.png)

As we can see in the above image, the code is raising a "divide by zero" but it's not showing where it happened - just that it's on the second line of the file.

This is the stacktrace after my changes:

![image](https://cloud.githubusercontent.com/assets/138037/17593678/15e4f858-5fbd-11e6-8042-6210bb3c0b00.png)

Now, the stacktrace shows that our exception started at line 6, then 3, then 4.

As for the strange name (`form-init<somebignumber>`), I wasn't able to find out what's wrong. On the "send" documentation, it says that this is the correct parameter and even `clojure.core/*file*` is bound to the correct name, but `pst` is unable to understand it. Still, beter than nothing :smile: 
