### PR TITLE
BUG: a loading icon can overlay the previous inline-result

### DIFF
--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -158,10 +158,6 @@ class Repl
   # be of the shape like the following.
   # ["text for display", {button options}, [childtree1, childtree2, ...]]
   displayInline: (editor, range, tree, error=false)->
-    end = range.end.row
-
-    # Remove the existing view if there is one
-    @ink.Result.removeLines(editor, end, end)
 
     # Defines a recursive function that can convert the tree of values to
     # display into an Atom Ink tree view. Sub-branches are expandable.
@@ -179,6 +175,7 @@ class Repl
     view = recurseTree(tree)
 
     # Add new inline view
+    end = range.end.row
     r = new @ink.Result editor, [end, end],
           content: view, error: error, type: if error then 'block' else 'inline'
 
@@ -240,6 +237,8 @@ class Repl
     if options.inlineOptions?
       editor = options.inlineOptions.editor
       range = options.inlineOptions.range
+      # Remove the existing view if there is one
+      @ink.Result.removeLines(editor, range.row.end, range.row.end)
       # use the id for asynchronous eval/result
       spinid = @loadingIndicator.startAt(editor, range)
 


### PR DESCRIPTION
avoid having a loading indicator and an inline result on the same position. If that happens:
- delete previous inline result
- start loading indicator
- stop loading indicator
- create new result if requested
