### PR TITLE
Fix autocomplete if it fails.

### DIFF
--- a/lib/completion-provider.coffee
+++ b/lib/completion-provider.coffee
@@ -84,6 +84,7 @@ module.exports =
             resultHandler: (result)->
               if result.error
                 console.log result.error
+                resolve []
               else
                 completions = window.protoRepl.parseEdn(result.value)
                 suggestions = (completionToSuggestion(prefix, c) for c in completions)


### PR DESCRIPTION
I'm doing some ClojureScript development right now. I know that compliment doesn't work with cljs, but when it fails to require it, it doesn't even show default Atom's autocomplete - just silently fails and logs something on console.

This PR will just return an empty completion, and Atom will work with it's default autocomplete just fine. Don't know if this is the desired behavior...