### PR TITLE
Add '=' and '_' to the list of allowed var characters

### DIFF
--- a/lib/editor-utils.coffee
+++ b/lib/editor-utils.coffee
@@ -202,4 +202,4 @@ module.exports = EditorUtils =
 
   # Determines if a cursor is within a range of text of a var and returns the text
   getClojureVarUnderCursor: (editor)->
-    editor.getWordUnderCursor wordRegex: /[a-zA-Z0-9\-.$!?\/><*]+/
+    editor.getWordUnderCursor wordRegex: /[a-zA-Z0-9\-.$!?\/><*=_]+/


### PR DESCRIPTION
Vars or namespaces mapped to symbols containing characters `=` or `_` cannot be looked up by `Open Selected Var or Namespace` currently. This is due to the regex at https://github.com/jasongilman/proto-repl/blob/master/lib/editor-utils.coffee#L205. This patch extends the regex to allow for these characters.