### PR TITLE
Using edn_reader to parse namespace declarations

### DIFF
--- a/lib/editor-utils.coffee
+++ b/lib/editor-utils.coffee
@@ -1,4 +1,5 @@
 {CompositeDisposable, Range, Point} = require 'atom'
+edn_reader = require './proto_repl/proto_repl/edn_reader.js'
 
 module.exports = EditorUtils =
 
@@ -10,11 +11,12 @@ module.exports = EditorUtils =
   # Finds a Clojure Namespace declaration in the editor and returns the name
   # of the namespace.
   findNsDeclaration: (editor)->
-    nsName = null
-    editor.scan /\(ns ([^\s\)]+)/, ({match, stop})->
-      nsName = match[1]
-      stop()
-    nsName
+    for range in @getTopLevelRanges(editor)
+      txt = editor.getTextInBufferRange(range)
+      try
+        return edn_reader.parse(txt)[1] if txt.match(/^\(ns /)
+      catch e
+        return null
 
   # Returns true if the position in the text editor is in a Markdown file in a
   # code block that contains Clojure.


### PR DESCRIPTION
`findNsDeclaration` now works with code like the one below:

```clojure
(ns ^{:doc "foo"
         :author "f@oo.com"}
    foo.bar)
```

Fixes #152 