### PR TITLE
Proposed fix for #229

### DIFF
--- a/lib/views/repl-text-editor.coffee
+++ b/lib/views/repl-text-editor.coffee
@@ -151,6 +151,8 @@ class ReplTextEditor
     @textEditor.buffer.applyChange = (change) ->
       {newStart, oldExtent, newExtent} = change
       start = Point.fromObject(newStart)
+      newExtent = newExtent or
+        Range.fromText(newStart, change.newText).getExtent()
       changeForCompare =
         oldRange: Range(start, start.traverse(oldExtent))
         newRange: Range(start, start.traverse(newExtent))


### PR DESCRIPTION
Recent changes in Atom have changed the parameters passed to the `applyChange` function. This causes an uncaught type error when using the 'basic' REPL window. The Ink REPL window is not affected.

Note that `applyChange` itself and code used in the fix is using non-public API, so please check this is acceptable.

Fixes #229 