### PR TITLE
Only wrap code in a do block when there are multiple statements

### DIFF
--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -348,8 +348,8 @@ module.exports = ProtoRepl =
         editor: editor
         range: range
       options.displayCode = selectedText
-      # Selected code is executed in a do block so only a single value is returned.
-      @executeCodeInNs("(do #{selectedText})", options)
+      options.doBlock = true
+      @executeCodeInNs(selectedText, options)
 
   # Executes the block of code near the cursor.
   # Valid options:

--- a/lib/views/ink-console.coffee
+++ b/lib/views/ink-console.coffee
@@ -115,6 +115,4 @@ class InkConsole
     if not atom.config.get('proto-repl.displayExecutedCodeInRepl')
       @displayExecutedCode(code)
 
-    # Wrap code in do block so that multiple statements entered at the REPL
-    # will execute all of them
-    window.protoRepl.executeCode("(do #{code})", displayCode: code)
+    window.protoRepl.executeCode(code, displayCode: code, doBlock: true)

--- a/lib/views/repl-text-editor.coffee
+++ b/lib/views/repl-text-editor.coffee
@@ -244,6 +244,4 @@ class ReplTextEditor
         code = @enteredText()
         @clearEnteredText()
         @replHistory.setLastTextAndAddNewEntry(code)
-        # Wrap code in do block so that multiple statements entered at the REPL
-        # will execute all of them
-        window.protoRepl.executeCode("(do #{code})", displayCode: code)
+        window.protoRepl.executeCode(code, displayCode: code, doBlock: true)


### PR DESCRIPTION
It looks like the reason that sending commands such as `:cljs/quit` to Figwheel through Proto REPL doesn't work is because it's being sent as `(do :cljs/quit)`, which doesn't actually quit the Figwheel REPL.

This PR adds a check to the to-be-sent code to count how many statements it contains and doesn't wrap it in a `do` block if the code is a single statement.

With this change, I'm able to connect to Figwheel, run Figwheel's control commands, and close it with `:cljs/quit`!

Related to issue #54 