### PR TITLE
update scope for new ink version

### DIFF
--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -180,11 +180,8 @@ class Repl
 
     # Add new inline view
     r = new @ink.Result editor, [end, end],
-          content: view, error: error, type: if error then 'block' else 'inline'
-
-    # Adding the class here lets us apply proto repl specific styles to the display.
-    r.view.classList.add 'proto-repl'
-
+          content: view, error: error, {type: if error then 'block' else 'inline',
+                                        scope: 'proto-repl'}
 
   # Makes an inline displaying result handler
   # * editor - the text editor to show the inline display in


### PR DESCRIPTION
This is an update to ensure proto-repl's compatibility with the next ink version. 
https://github.com/JunoLab/atom-ink/pull/127 broke the hack of adding a class to the result directly via `r.view.classList.add` and introduced a `scope` keyword for the `Result` constructor instead.

It would also make sense to adapt your stylesheets to use the adaptive width introduced in the abovementioned PR. Should you run into any troubles with ink master feel free to ping me. :)