### PR TITLE
nrepl connection dialog switch inputs by 'tab'

### DIFF
--- a/keymaps/proto-repl.cson
+++ b/keymaps/proto-repl.cson
@@ -103,3 +103,7 @@
  .platform-linux ink-console atom-text-editor[data-grammar~="clojure"],
  .platform-darwin ink-console atom-text-editor[data-grammar~="clojure"]':
   'enter': 'editor:newline'
+
+# Nrepl connection dialog keybindings
+'atom-workspace .proto-repl.proto-repl-nrepl-connection-dialog':
+  'tab': 'proto-repl:remote-nrepl-focus-next'

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -135,6 +135,7 @@ module.exports = ProtoRepl =
       'proto-repl:interrupt': => @interrupt()
       'proto-repl:autoeval-file': => @autoEvalCurrent()
       'proto-repl:stop-autoeval-file': => @stopAutoEvalCurrent()
+      'proto-repl:remote-nrepl-focus-next': => @remoteNreplFocusNext()
 
   # Called by autocomplete-plus to return our Clojure provider
   provide: ->
@@ -750,3 +751,6 @@ module.exports = ProtoRepl =
                 atom.workspace.open(file, {initialLine: line-1, searchAllPanes: true})
               else
                 @stderr("Error trying to open: #{result.error}")
+
+  remoteNreplFocusNext: ->
+    @connectionView.toggleFocus()

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -753,4 +753,4 @@ module.exports = ProtoRepl =
                 @stderr("Error trying to open: #{result.error}")
 
   remoteNreplFocusNext: ->
-    @connectionView.toggleFocus()
+    @connectionView ? @connectionView.toggleFocus()

--- a/lib/views/nrepl-connection-view.coffee
+++ b/lib/views/nrepl-connection-view.coffee
@@ -61,3 +61,9 @@ module.exports =
     resetEditors: ->
       @hostEditor.setText('')
       @portEditor.setText('')
+
+    toggleFocus: ->
+      if @hostEditor.element.hasFocus()
+        @portEditor.element.focus()
+      else
+        @hostEditor.element.focus()


### PR DESCRIPTION
When I called `Remote Nrepl Connection` and filled in `host` field I was confused that I have to use _mouse_ to click `port` field then. Maybe I do something wrong, but it is common practice to use `tab` for such things even in webpages.

This PR offers such functionality for `Remote Nrepl Connection` modal.