### PR TITLE
Add Gradle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Proto REPL is a Clojure development environment and REPL for [Atom](https://atom
 These are the instructions get up and running quickly. Most features will work but for the best results see [Option 2](#option-2-opinionated-complete-best-way-to-setup-atom-for-clojure-development-with-proto-repl).
 
 1. Install [Atom](https://atom.io/).
-2. Install [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and [Leiningen](http://leiningen.org/) or [Boot](https://github.com/boot-clj/boot)
+2. Install [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and [Leiningen](http://leiningen.org/) or [Boot](https://github.com/boot-clj/boot) or have a project with a [Gradle](https://gradle.org) wrapper.
 3. Go to Atom settings, select "+ Install" and search for "proto-repl".
 5. Install the Atom Ink package.
 6. Go to the Proto REPL Settings (Atom Preferences, then packages, then Proto REPL)
 7. Modify "Lein Path" or "Boot Path" to the path where Leiningen/Boot was installed. Use `which lein` in a terminal to get the path.
   * This should be something like `/some/path/bin/lein`
-  * If using Boot deselect the option for Prefer Leiningen.
+  * Gradle projects will always look for the wrapper (standalone Gradle installs are not supported).
+  * If your project has multiple build configurations, use the Preferred Repl option to choose which of lein, boot, or gradle should be preferred.
 8. Restart Atom.
 9. [Start a REPL](#start-a-local-clojure-repl)
 
@@ -56,10 +57,10 @@ Add the [![Clojars Project](https://img.shields.io/clojars/v/proto-repl.svg)](ht
 
 ### Start a Local Clojure REPL
 
-A local Proto REPL primarily works with projects using [Leiningen](http://leiningen.org) or [Boot](http://boot-clj.com/).
+A local Proto REPL primarily works with projects using [Leiningen](http://leiningen.org), [Boot](http://boot-clj.com/), or [Gradle](https://gradle.org) (with [gradle-clojure](https://github.com/gradle-clojure/gradle-clojure)).
 
-1. Open your Clojure project in Atom. (See [the Leiningen tutorial](https://github.com/technomancy/leiningen/blob/stable/doc/TUTORIAL.md#creating-a-project)
-or [the Boot tutorial](https://github.com/boot-clj/boot#install) for help creating a new project.)
+1. Open your Clojure project in Atom. (See [the Leiningen tutorial](https://github.com/technomancy/leiningen/blob/stable/doc/TUTORIAL.md#creating-a-project),
+ [the Boot tutorial](https://github.com/boot-clj/boot#install), or [the gradle-clojure documentation](https://github.com/gradle-clojure/gradle-clojure/blob/master/README.md) for help creating a new project.)
 2. Start the REPL by bring up the Command Palette (cmd-shift-p) and select "Proto REPL: Toggle"
   * The REPL can also be started by using the [keyboard shortcuts documented below](#keybindings-and-events).
 
@@ -220,7 +221,7 @@ There's currently a limit of 20 saved values in proto-repl-lib. After debugging 
 
 * [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
   * Not required for self hosted REPL.
-* [Leiningen](http://leiningen.org) or [Boot](https://github.com/boot-clj/boot)
+* [Leiningen](http://leiningen.org), [Boot](https://github.com/boot-clj/boot), or [Gradle](https://gradle.org) (requires use of Gradle wrapper)
   * Not required for self hosted REPL.
 * [Atom Ink](https://atom.io/packages/ink)
   * This is an optional feature but many of Proto REPL's advanced features won't work without it.

--- a/lib/process/gradle-runner.coffee
+++ b/lib/process/gradle-runner.coffee
@@ -53,6 +53,9 @@ module.exports = (currentWorkingDir, args) ->
         when 'input'
           replProcess.stdin.write(text)
         when 'kill'
-          replProcess.kill("SIGKILL")
+          # Send CTRL+D to Gradle to tell it to stop the NREPL gracefully
+          replProcess.stdin.write("\x04")
+          run = () -> replProcess.kill("SIGKILL")
+          setTimeout run, 2500
     catch error
       console.error error

--- a/lib/process/gradle-runner.coffee
+++ b/lib/process/gradle-runner.coffee
@@ -1,0 +1,58 @@
+childProcess = require 'child_process'
+path = require 'path'
+fs = require 'fs'
+_ = require 'underscore'
+
+filteredEnv = _.omit process.env, 'ATOM_HOME', 'ATOM_SHELL_INTERNAL_RUN_AS_NODE', 'GOOGLE_API_KEY', 'NODE_ENV', 'NODE_PATH', 'userAgent', 'taskPath'
+
+
+module.exports = (currentWorkingDir, args) ->
+  callback = @async()
+
+  # The nREPL port is extracted from the output of the REPL process.
+  # proto-repl-process:nrepl-port is emitted with the nREPL port is found.
+  portFound = false
+
+  processData = (data) ->
+    dataStr = data.toString()
+
+    if !portFound
+      if match = dataStr.match(/.*nREPL.*port\s+(\d+)/)
+        portFound = true
+        port = Number(match[1])
+        emit('proto-repl-process:nrepl-port', port)
+
+    emit('proto-repl-process:data', dataStr)
+
+  try
+    if process.platform == "win32"
+      # Windows
+      gradleExec = "gradlew.bat"
+      replProcess = childProcess.spawn gradleExec, args, cwd: currentWorkingDir, env: filteredEnv, shell: true
+    else
+      # Mac/Linux
+      gradleExec = "gradlew"
+      replProcess = childProcess.spawn gradleExec, args, cwd: currentWorkingDir, env: filteredEnv
+
+    replProcess.stdout.on 'data', processData
+    replProcess.stderr.on 'data', processData
+
+    replProcess.on 'error', (error)->
+      processData("Error starting repl: " + error +
+      "\nYou may need to configure the gradle path or args in proto-repl settings\n")
+
+    replProcess.on 'close', (code)->
+      emit('proto-repl-process:exit')
+      callback()
+  catch error
+    processData("Error starting repl: " + error)
+
+  process.on 'message', ({event, text}={}) ->
+    try
+      switch event
+        when 'input'
+          replProcess.stdin.write(text)
+        when 'kill'
+          replProcess.kill("SIGKILL")
+    catch error
+      console.error error

--- a/lib/process/local-repl-process.coffee
+++ b/lib/process/local-repl-process.coffee
@@ -156,12 +156,6 @@ class LocalReplProcess
 
   # Stops the running process
   stop: ()->
-    try
-      # Tell the process to shutdown
-      @conn.sendCommand EXIT_CMD,true, => return
-      @conn.close()
-    catch error
-      console.log("Error trying to send exit command to REPL.", error)
-    # Kill the process to make sure.
+    @conn.close()
     @process?.send event: 'kill'
     @process = null

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -42,10 +42,17 @@ module.exports = ProtoRepl =
       description: 'The arguments to be passed to boot. For advanced users only.'
       type: 'string'
       default: "--no-colors dev repl --server wait"
-    preferLein:
-      description: "Sets whether to prefer Leiningen if a boot and lein build file is found."
-      type: 'boolean'
-      default: true
+    gradleArgs:
+      description: 'The arguments to be passed to gradle. For advanced users only.'
+      type: 'string'
+      default: ":clojureRepl --console=plain --quiet"
+    preferredRepl:
+      description: "Sets the order of preference for REPLs, if your project has multiple build files."
+      type: 'array'
+      default: ['lein', 'boot', 'gradle']
+      items:
+          type: 'string'
+          enum: ['lein', 'boot', 'gradle']
     showInlineResults:
       description: "Shows inline results of code execution. Install Atom Ink package to use this."
       type: 'boolean'


### PR DESCRIPTION
The gradle-clojure plugin [1] is adding Clojure support to Gradle
and now (as of 0.3.0-rc.2) supports starting an nREPL server. This
adds support for Gradle in addition to the existing Boot and
Leiningen support.

The Gradle support does not specify a gradlePath config setting, like
Lein and Boot do, since idiomatic Gradle usage uses a wrapper shell
launcher included within the project. As such, we search for that
gradlew file instead of a build.gradle to determine if it supports
Gradle.

Previously, there was a boolean preferLein option to choose between
Lein and Boot, if both were present. With a third tool, this gets a
little more complicated. This is now supported via an array of
enumerated values to indicate order of preference.

There may be a simpler approach to get at the gist of the feature.

[1] https://github.com/gradle-clojure/gradle-clojure