### PR TITLE
Fixed loading spinners not getting cleaned up when exceptions are thrown in Boot REPLs

### DIFF
--- a/lib/process/nrepl-connection.coffee
+++ b/lib/process/nrepl-connection.coffee
@@ -172,8 +172,10 @@ class NReplConnection
             for msg in messages
               if msg.value
                 resultHandler(value: msg.value)
-              else if msg.err
+              else if msg.err # Catch Leiningen errors
                 resultHandler(error: msg.err)
+              else if msg.ex # Catch Boot errors
+                resultHandler(error: msg.ex)
         catch error
           console.error error
           atom.notifications.addError "Error in handler: " + error,


### PR DESCRIPTION
Previously, any code executed in a Boot REPL (remote or local) that threw an exception would cause a spinner to appear in the editor and never disappear. The problem is, Boot returns exceptions in a slightly different way, causing proto-repl to ignore the returned message and never trigger the result handler which would cleanup the spinner.

This now checks for Boot exception messages and calls the result handler fixing the issue.

Fixes issues  #209 and #215 for local and remote REPLs.


To reproduce and verify:

1. Start a REPL server with Boot or Leiningen and connect to it with proto-repl:
```
boot repl --server --port 4000 -- wait
```
```
lein repl :headless :port 4000
```

2. Execute any code from inside a file in Atom to throw an exception:
```
(/ 1 0)
```