### PR TITLE
Add support for Clojure 1.9 CLI REPL

### DIFF
--- a/lib/process/clojure-runner.coffee
+++ b/lib/process/clojure-runner.coffee
@@ -6,8 +6,18 @@ _ = require 'underscore'
 filteredEnv = _.omit process.env, 'ATOM_HOME', 'ATOM_SHELL_INTERNAL_RUN_AS_NODE', 'GOOGLE_API_KEY', 'NODE_ENV', 'NODE_PATH', 'userAgent', 'taskPath'
 
 
-module.exports = (currentWorkingDir, clojurePath, args) ->
+module.exports = (currentWorkingDir, clojurePath) ->
   callback = @async()
+
+  args = [
+    "-e",
+    "(do
+      (require '[clojure.tools.nrepl.server :refer [start-server]])
+      (let [port (:port (start-server))]
+        (println (str \"nREPL server started on port \" port \" on host 127.0.0.1\"))
+        (println (str \"- nrepl://127.0.0.1:\" port))))",
+    "-r"
+  ]
 
   # The nREPL port is extracted from the output of the REPL process. We could
   # look on the file system for the .nrepl-port file which is more standard
@@ -28,7 +38,7 @@ module.exports = (currentWorkingDir, clojurePath, args) ->
 
   try
     # Mac/Linux
-    clojureExec = "clojure"
+    clojureExec = "clj"
     envPath = filteredEnv["PATH"] || ""
     filteredEnv["PATH"] = envPath + path.delimiter + clojurePath
     replProcess = childProcess.spawn clojureExec, args, cwd: currentWorkingDir, env: filteredEnv

--- a/lib/process/clojure-runner.coffee
+++ b/lib/process/clojure-runner.coffee
@@ -1,0 +1,57 @@
+childProcess = require 'child_process'
+path = require 'path'
+fs = require 'fs'
+_ = require 'underscore'
+
+filteredEnv = _.omit process.env, 'ATOM_HOME', 'ATOM_SHELL_INTERNAL_RUN_AS_NODE', 'GOOGLE_API_KEY', 'NODE_ENV', 'NODE_PATH', 'userAgent', 'taskPath'
+
+
+module.exports = (currentWorkingDir, clojurePath, args) ->
+  callback = @async()
+
+  # The nREPL port is extracted from the output of the REPL process. We could
+  # look on the file system for the .nrepl-port file which is more standard
+  # but there are issues if you want to start multiple REPLs in the same project.
+  # proto-repl-process:nrepl-port is emitted with the nREPL port is found.
+  portFound = false
+
+  processData = (data) ->
+    dataStr = data.toString()
+
+    if !portFound
+      if match = dataStr.match(/.*nREPL.*port (\d+)/)
+        portFound = true
+        port = Number(match[1])
+        emit('proto-repl-process:nrepl-port', port)
+
+    emit('proto-repl-process:data', dataStr)
+
+  try
+    # Mac/Linux
+    clojureExec = "clojure"
+    envPath = filteredEnv["PATH"] || ""
+    filteredEnv["PATH"] = envPath + path.delimiter + clojurePath
+    replProcess = childProcess.spawn clojureExec, args, cwd: currentWorkingDir, env: filteredEnv
+
+    replProcess.stdout.on 'data', processData
+    replProcess.stderr.on 'data', processData
+
+    replProcess.on 'error', (error)->
+      processData("Error starting repl: " + error +
+      "\nYou may need to configure the clojure path in proto-repl settings\n")
+
+    replProcess.on 'close', (code)->
+      emit('proto-repl-process:exit')
+      callback()
+  catch error
+    processData("Error starting repl: " + error)
+
+  process.on 'message', ({event, text}={}) ->
+    try
+      switch event
+        when 'input'
+          replProcess.stdin.write(text)
+        when 'kill'
+          replProcess.kill("SIGKILL")
+    catch error
+      console.error error

--- a/lib/process/local-repl-process.coffee
+++ b/lib/process/local-repl-process.coffee
@@ -120,8 +120,7 @@ class LocalReplProcess
       when "clojure"
         @process = Task.once ClojureRunner,
                              path.resolve(projectPath),
-                             atom.config.get('proto-repl.clojurePath').replace("/clojure",""),
-                             atom.config.get('proto-repl.clojureArgs').split(" ")
+                             atom.config.get('proto-repl.clojurePath').replace("/clj","")
       # when "lein" then
       else
         @process = Task.once LeinRunner,

--- a/lib/process/local-repl-process.coffee
+++ b/lib/process/local-repl-process.coffee
@@ -2,6 +2,7 @@
 LeinRunner = require.resolve './lein-runner'
 BootRunner = require.resolve './boot-runner'
 GradleRunner = require.resolve './gradle-runner'
+ClojureRunner = require.resolve './clojure-runner'
 path = require 'path'
 fs = require('fs')
 NReplConnection = require './nrepl-connection'
@@ -46,7 +47,8 @@ class LocalReplProcess
     if currentPath != parentDirectory and limit < 100
       matches = fs.readdirSync(currentPath).filter (f) ->
         f == "project.clj" or f == "build.boot" or
-        f == "gradlew" or f == "gradlew.bat"
+        f == "gradlew" or f == "gradlew.bat" or
+        f == "deps.edn"
 
       if currentPath and matches.length == 0
         @getRootProject(parentDirectory, limit + 1)
@@ -83,6 +85,7 @@ class LocalReplProcess
     replsFound = []
     replsFound.push "boot" if fs.existsSync(projectPath + "/build.boot")
     replsFound.push "lein" if fs.existsSync(projectPath + "/project.clj")
+    replsFound.push "clojure" if fs.existsSync(projectPath + "/deps.edn")
     replsFound.push "gradle" if fs.existsSync(projectPath + "/gradlew") or
       fs.existsSync(projectPath + "/gradlew.bat")
 
@@ -114,6 +117,11 @@ class LocalReplProcess
                              path.resolve(projectPath),
                              atom.config.get('proto-repl.bootPath').replace("/boot",""),
                              atom.config.get('proto-repl.bootArgs').split(" ")
+      when "clojure"
+        @process = Task.once ClojureRunner,
+                             path.resolve(projectPath),
+                             atom.config.get('proto-repl.clojurePath').replace("/clojure",""),
+                             atom.config.get('proto-repl.clojureArgs').split(" ")
       # when "lein" then
       else
         @process = Task.once LeinRunner,

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -29,7 +29,7 @@ module.exports = ProtoRepl =
     clojurePath:
       description: 'The path to the clojure executable.'
       type: 'string'
-      default: 'clojure'
+      default: 'clj'
     bootPath:
       description: 'The path to the boot executable.'
       type: 'string'
@@ -42,10 +42,6 @@ module.exports = ProtoRepl =
       description: 'The arguments to be passed to leiningen. For advanced users only.'
       type: 'string'
       default: "repl :headless"
-    clojureArgs:
-      description: 'The arguments to be passed to clojure. For advanced users only.'
-      type: 'string'
-      default: "-r"
     bootArgs:
       description: 'The arguments to be passed to boot. For advanced users only.'
       type: 'string'

--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -26,6 +26,10 @@ module.exports = ProtoRepl =
       description: 'The path to the lein executable.'
       type: 'string'
       default: 'lein'
+    clojurePath:
+      description: 'The path to the clojure executable.'
+      type: 'string'
+      default: 'clojure'
     bootPath:
       description: 'The path to the boot executable.'
       type: 'string'
@@ -38,6 +42,10 @@ module.exports = ProtoRepl =
       description: 'The arguments to be passed to leiningen. For advanced users only.'
       type: 'string'
       default: "repl :headless"
+    clojureArgs:
+      description: 'The arguments to be passed to clojure. For advanced users only.'
+      type: 'string'
+      default: "-r"
     bootArgs:
       description: 'The arguments to be passed to boot. For advanced users only.'
       type: 'string'
@@ -49,10 +57,10 @@ module.exports = ProtoRepl =
     preferredRepl:
       description: "Sets the order of preference for REPLs, if your project has multiple build files."
       type: 'array'
-      default: ['lein', 'boot', 'gradle']
+      default: ['lein', 'boot', 'gradle', 'clojure']
       items:
           type: 'string'
-          enum: ['lein', 'boot', 'gradle']
+          enum: ['lein', 'boot', 'gradle', 'clojure']
     showInlineResults:
       description: "Shows inline results of code execution. Install Atom Ink package to use this."
       type: 'boolean'


### PR DESCRIPTION
This PR adds support for Clojure's 1.9 `clj` command REPL.

- REPL detection is based on the presence of `deps.edn` file
- `clj` command executes with a string of code that requires `tools.nrepl` ns, starts nREPL server and prints server port for proto-repl to pick it up.
- `tools.nrepl` should be added to `:deps`

Attaching screenshots with working  minimal

<img width="677" alt="screen shot 2017-12-21 at 1 07 09 am" src="https://user-images.githubusercontent.com/1355501/34233241-dbb3bd42-e5ec-11e7-831a-da98437257f0.png">
<img width="662" alt="screen shot 2017-12-21 at 1 08 09 am" src="https://user-images.githubusercontent.com/1355501/34233246-e237b5c4-e5ec-11e7-9ced-01017100dc57.png">