### PR TITLE
Inject proto-repl and tools.nrepl deps for clojure CLI based projects

### DIFF
--- a/lib/process/clojure-runner.coffee
+++ b/lib/process/clojure-runner.coffee
@@ -10,6 +10,8 @@ module.exports = (currentWorkingDir, clojurePath) ->
   callback = @async()
 
   args = [
+    "-Sdeps",
+    "{:deps {proto-repl {:mvn/version \"0.3.1\"} org.clojure/tools.nrepl {:mvn/version \"0.2.12\"}}}",
     "-e",
     "(do
       (require '[clojure.tools.nrepl.server :refer [start-server]])


### PR DESCRIPTION
This is a follow up PR for #289. Currently a project owner has to specify manually `proto-repl` and `tools.nrepl` deps in his `deps.edn` in order for Proto REPL to be able to start nREPL server. This PR ads `-Sdeps` CLI flag which injects both dependencies that automatically merged with `deps.edn` contents when the REPL starts. Cider does this as well.