### PR TITLE
Don't use detached with Windows; kill process with taskkill

### DIFF
--- a/lib/process/lein-runner.coffee
+++ b/lib/process/lein-runner.coffee
@@ -35,7 +35,7 @@ module.exports = (currentWorkingDir, leinPath, args) ->
         leinExec = path.join(leinPath, "lein.bat")
       envPath = filteredEnv["Path"] || ""
       filteredEnv["Path"] = envPath + path.delimiter + leinPath
-      replProcess = childProcess.spawn leinExec, args, cwd: currentWorkingDir, env: filteredEnv, shell: true, detached: true
+      replProcess = childProcess.spawn leinExec, args, cwd: currentWorkingDir, env: filteredEnv, shell: true
     else
       # Mac/Linux
       leinExec = "lein"
@@ -62,6 +62,11 @@ module.exports = (currentWorkingDir, leinPath, args) ->
         when 'input'
           replProcess.stdin.write(text)
         when 'kill'
-          process.kill(-replProcess.pid, 'SIGKILL')
+          if process.platform == "win32"
+            # Windows, doesn't appear to handle SIGKILL and running detached, so use native taskkill instead
+            childProcess.spawn("taskkill", ["/pid", replProcess.pid, '/f', '/t']);
+          else
+            # Mac/Linux
+            process.kill(-replProcess.pid, 'SIGKILL')
     catch error
       console.error error


### PR DESCRIPTION
Fixes https://github.com/jasongilman/proto-repl/issues/300

It appears that spawning detached in Windows isn't the correct approach. This reverts 'detached' when running in Windows. Also, nodejs and killing the child process also doesn't play nicely in Windows, so this uses the native `taskkill` command instead. 

This commit fixes the issue of the extra terminal window starting in Windows. It also fixes the killing of the JVM process associated with the REPL on REPL-exit (as the original PR intended).

@jasongilman Please take a look at this one soon, as proto-repl is unusable on Windows in the current release.