### PR TITLE
Add remote nrepl hook

### DIFF
--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -265,6 +265,12 @@ module.exports = ProtoRepl =
     @connectionView ?= new NReplConnectionView(confirmCallback)
     @connectionView.show()
 
+  remoteNReplHook: ({port, host}) ->
+    unless @repl
+      @repl = new Repl(@extensionsFeature)
+      @prepareRepl(@repl)
+    @repl.startRemoteReplConnection({port, host})
+
   selfHostedRepl: ->
     if @repl == null
       @repl = new Repl(@extensionsFeature)


### PR DESCRIPTION
This PR adds a hook for starting a new remote nrepl connection with the given host and port. This allows users to define commands in their init script for quickly starting frequently used connections. For example:

```coffeescript
atom.commands.add 'atom-text-editor', 'custom:example-repl', ->
  protoRepl.remoteNReplHook({
    host: "example.clojure-project.com",
    port: 9656
  })
```