### PR TITLE
improve the output format of print-var-documentation

### DIFF
--- a/lib/repl.coffee
+++ b/lib/repl.coffee
@@ -302,3 +302,6 @@ class Repl
 
   stdout: (text)->
     @replView?.stdout(text)
+
+  doc: (text)->
+    @replView?.doc(text)

--- a/lib/views/ink-console.coffee
+++ b/lib/views/ink-console.coffee
@@ -74,6 +74,10 @@ class InkConsole
   stdout: (text)->
     @console?.stdout(text)
 
+  # Writes information with book icon.
+  doc: (text)->
+    @console?.output({type: 'info', icon: 'book', text: text})
+
   # Writes results from Clojure execution to the REPL. The results are syntactically
   # highlighted as Clojure code.
   result: (text)->

--- a/lib/views/repl-text-editor.coffee
+++ b/lib/views/repl-text-editor.coffee
@@ -234,6 +234,9 @@ class ReplTextEditor
   result: (text)->
     @appendText(text)
 
+  doc: (text)->
+    @appendText(text)
+
   displayExecutedCode: (code)->
     @appendText(code)
 


### PR DESCRIPTION
This PR improves the output of the print-var-documentation command.

current output:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/9014937/62002320-69b59880-b0c7-11e9-8ee6-5883f2b05f81.png">


new output:
<img width="552" alt="image" src="https://user-images.githubusercontent.com/9014937/62002327-7b973b80-b0c7-11e9-8366-29ef11241061.png">

The current code also depends on the stdout coming back to through the repl connection, which may not always happen. (It doesn't with the shadow-cljs repl I'm using.) The new code uses with-out-str to get the doc output through the return value.

I also added an `allSessions` option to `NReplConnection.sendCommand` to make it easier to switch all sessions to ClojureScript when using shadow-cljs or piggyback. This is needed because the new doc command uses `displayInRepl: false` and so the command goes to `cmdSession` instead of `session`. Users can define commands like this in their init.coffee / init.js to switch between Clojure and ClojureScript repls:

```
atom.commands.add('atom-workspace', 'proto-repl-custom:switch-to-shadow-cljs-app-repl', () =>
  protoRepl.executeCodeInNs('(shadow.cljs.devtools.api/nrepl-select :app)', {allSessions: true}));

atom.commands.add('atom-workspace', 'proto-repl-custom:exit-cljs-repl', () =>
  protoRepl.executeCodeInNs(':cljs/quit', {allSessions: true}));
```
