### PR TITLE
Update toolbar icons

### DIFF
--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -158,17 +158,17 @@ module.exports = ProtoRepl =
   consumeToolbar: (toolbar) ->
     @toolbar = toolbar 'proto-repl'
     @toolbar.addButton
-      icon: 'android-refresh'
+      icon: 'md-refresh'
       iconset: 'ion'
       callback: 'proto-repl:refresh-namespaces'
       tooltip: 'Refresh Namespaces'
     @toolbar.addButton
-      icon: 'android-sync'
+      icon: 'md-sync'
       iconset: 'ion'
       callback: 'proto-repl:super-refresh-namespaces'
       tooltip: 'Clear and Refresh Namespaces'
     @toolbar.addButton
-      icon: 'speedometer'
+      icon: 'md-speedometer'
       iconset: 'ion'
       callback: 'proto-repl:run-all-tests'
       tooltip: 'Run All Tests'
@@ -177,25 +177,25 @@ module.exports = ProtoRepl =
 
     @toolbar.addButton
       icon: 'paypal'
-      iconset: 'fa'
+      iconset: 'fab'
       callback: 'proto-repl:pretty-print'
       tooltip: 'Pretty Print'
 
     @toolbar.addSpacer()
 
     @toolbar.addButton
-      icon: 'code-download'
+      icon: 'md-code-download'
       iconset: 'ion'
       callback: 'proto-repl:toggle-auto-scroll'
       tooltip: 'Toggle Auto Scroll'
     @toolbar.addButton
-      icon: 'trash-a'
+      icon: 'md-trash'
       iconset: 'ion'
       callback: 'proto-repl:clear-repl'
       tooltip: 'Clear REPL'
     @toolbar.addSpacer()
     @toolbar.addButton
-      icon: 'power'
+      icon: 'md-power'
       iconset: 'ion'
       callback: 'proto-repl:exit-repl'
       tooltip: 'Quit REPL'


### PR DESCRIPTION
The latest release of the [tool-bar](https://github.com/suda/tool-bar) package introduced breaking icon font updates. As a result, icons were not being displayed on the toolbar. The PR update the toolbar icons to the right names. See [this discussion](https://discuss.atom.io/t/toolbar-icons-missing-on-several-toolbars/72553) for more info. All the icons are still the same. I just updated the prefixes and icon-set.