### PR TITLE
Update icon names for proto-repl tool-bar icons

### DIFF
--- a/lib/proto-repl.coffee
+++ b/lib/proto-repl.coffee
@@ -158,17 +158,17 @@ module.exports = ProtoRepl =
   consumeToolbar: (toolbar) ->
     @toolbar = toolbar 'proto-repl'
     @toolbar.addButton
-      icon: 'android-refresh'
+      icon: 'md-refresh'
       iconset: 'ion'
       callback: 'proto-repl:refresh-namespaces'
       tooltip: 'Refresh Namespaces'
     @toolbar.addButton
-      icon: 'android-sync'
+      icon: 'md-sync'
       iconset: 'ion'
       callback: 'proto-repl:super-refresh-namespaces'
       tooltip: 'Clear and Refresh Namespaces'
     @toolbar.addButton
-      icon: 'speedometer'
+      icon: 'md-speedometer'
       iconset: 'ion'
       callback: 'proto-repl:run-all-tests'
       tooltip: 'Run All Tests'
@@ -176,7 +176,7 @@ module.exports = ProtoRepl =
     @toolbar.addSpacer()
 
     @toolbar.addButton
-      icon: 'paypal'
+      icon: 'file-code'
       iconset: 'fa'
       callback: 'proto-repl:pretty-print'
       tooltip: 'Pretty Print'
@@ -184,18 +184,18 @@ module.exports = ProtoRepl =
     @toolbar.addSpacer()
 
     @toolbar.addButton
-      icon: 'code-download'
+      icon: 'md-code-download'
       iconset: 'ion'
       callback: 'proto-repl:toggle-auto-scroll'
       tooltip: 'Toggle Auto Scroll'
     @toolbar.addButton
-      icon: 'trash-a'
+      icon: 'md-trash'
       iconset: 'ion'
       callback: 'proto-repl:clear-repl'
       tooltip: 'Clear REPL'
     @toolbar.addSpacer()
     @toolbar.addButton
-      icon: 'power'
+      icon: 'md-power'
       iconset: 'ion'
       callback: 'proto-repl:exit-repl'
       tooltip: 'Quit REPL'


### PR DESCRIPTION
The icon names for ion icon set require md- prefix and some names have changed. https://atom.io/packages/tool-bar#plugins
Without this, the tool bar does not show any icons in atom `1.58.0~pop1~1632508299~21.04~c480439` on `Pop!_OS 21.04`. The icons show up correctly now in all four built-in Atom themes.

![Screenshot from 2021-11-08 04-36-21](https://user-images.githubusercontent.com/1009523/140665335-a8a6eb9f-224c-495c-9086-6423333caac0.png)
![Screenshot from 2021-11-08 04-37-58](https://user-images.githubusercontent.com/1009523/140665342-f3b9a2c9-87dc-41c0-8310-269ecdbfb2ae.png)


